### PR TITLE
Allow fixtures to return data

### DIFF
--- a/django_e2e_runner/database/loaders.py
+++ b/django_e2e_runner/database/loaders.py
@@ -4,4 +4,4 @@ from django.utils.module_loading import import_string
 class ScriptFixtureLoader(object):
     def load(self, fixture_name):
         fixture_method = import_string('tests.fixtures.{}'.format(fixture_name))
-        fixture_method()
+        return fixture_method()

--- a/django_e2e_runner/views.py
+++ b/django_e2e_runner/views.py
@@ -12,9 +12,9 @@ def load_test_data(request, fixture_name):
     data_manager.pre_load_setup()
 
     fixture_loader = import_string(settings.FIXTURE_LOADER)()
-    fixture_loader.load(fixture_name)
+    fixture_data = fixture_loader.load(fixture_name)
 
-    return JsonResponse({'status': STATUS_OK_200})
+    return JsonResponse({'status': STATUS_OK_200, 'data': fixture_data})
 
 
 def rollback_test_data(request):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='django_e2e_runner',


### PR DESCRIPTION
In this PR i added possibility for code in fixtures to return data as a JSON response

Also I removed the reliance on `distutils` package as it is deprecated in newer versions of python: https://docs.python.org/3.10/library/distutils.html